### PR TITLE
Uncomment categories, comment out used space group

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -27,7 +27,8 @@ jobs:
       - name: Terraform Apply
         run: terraform apply -auto-approve
         env:
-          TF_VAR_jamfpro_client_id: 83dda510-158a-4e47-b50b-49dda56219a3
-          TF_VAR_jamfpro_client_secret: CTk1Rvu92UhJED0q6LQjfRzkhyA2ZrJzyhaRNFbNctW4G47m-_AUGqt41-KamWzk
-          TF_VAR_jamfpro_instance_url: https://techitout.jamfcloud.com
-          TF_VAR_jamfpro_auth_method: oauth2
+          JAMFPRO_INSTANCE_FQDN: https://techitout.jamfcloud.com
+          JAMFPRO_CLIENT_ID: 83dda510-158a-4e47-b50b-49dda56219a3
+          JAMFPRO_CLIENT_SECRET: CTk1Rvu92UhJED0q6LQjfRzkhyA2ZrJzyhaRNFbNctW4G47m-_AUGqt41-KamWzk
+          JAMFPRO_AUTH_METHOD: oauth2
+          # JAMFPRO_INSTANCE_FQDN: ${{ secrets.JAMFPRO_INSTANCE_FQDN }}

--- a/modules/configuration-jamf-pro-categories/main.tf
+++ b/modules/configuration-jamf-pro-categories/main.tf
@@ -17,15 +17,15 @@ resource "jamfpro_category" "category_communication" {
   priority = 9
 }
 
-# resource "jamfpro_category" "category_developer_tools" {
-#   name     = "Developer Tools"
-#   priority = 9
-# }
+resource "jamfpro_category" "category_developer_tools" {
+  name     = "Developer Tools"
+  priority = 9
+}
 
-# resource "jamfpro_category" "category_network" {
-#   name     = "Network Security"
-#   priority = 9
-# }
+resource "jamfpro_category" "category_network" {
+  name     = "Network Security"
+  priority = 9
+}
 
 resource "jamfpro_category" "category_printers" {
   name     = "Printers"

--- a/modules/configuration-jamf-pro-categories/main.tf
+++ b/modules/configuration-jamf-pro-categories/main.tf
@@ -42,7 +42,7 @@ resource "jamfpro_category" "category_security_compliance" {
   priority = 9
 }
 
-resource "jamfpro_category" "category_uninstallers" {
-  name     = "Uninstallers"
-  priority = 9
-}
+# resource "jamfpro_category" "category_uninstallers" {
+#   name     = "Uninstallers"
+#   priority = 9
+# }

--- a/modules/configuration-jamf-pro-smart-groups/main.tf
+++ b/modules/configuration-jamf-pro-smart-groups/main.tf
@@ -121,16 +121,16 @@ resource "jamfpro_smart_mobile_device_group" "group_last_checkin" {
   }
 }
 
-resource "jamfpro_smart_mobile_device_group" "group_used_space_above_75" {
-  name = "*Used Storage above 75 percent"
+# resource "jamfpro_smart_mobile_device_group" "group_used_space_above_75" {
+#   name = "*Used Storage above 75 percent"
 
-  criteria {
-    name        = "Used Space Percentage"
-    priority    = 0
-    search_type = "more than"
-    value       = "75"
-  }
-}
+#   criteria {
+#     name        = "Used Space Percentage"
+#     priority    = 0
+#     search_type = "more than"
+#     value       = "75"
+#   }
+# }
 
 resource "jamfpro_smart_mobile_device_group" "group_passcode_not_present" {
   name = "*Passcode Not Present"


### PR DESCRIPTION
Uncommented the 'Developer Tools' and 'Network Security' category resources in the Jamf Pro categories module. Commented out the 'Used Storage above 75 percent' smart group in the Jamf Pro smart groups module, possibly to disable its creation.

# Change

**_State your intended change to Experience Jamf_**

> Thank you for your contribution!
> Please include a summary of the change and which issue is fixed.
> Please also include relevant motivation and context.
> List any dependencies that are required for this change.

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
- [ ] Refactor (refactoring code, removing code, changing code structure)
- [ ] Release to main from staging branch

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] For module changes - I have included an example in the /examples directory and a README.md in the module root
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated spec.yaml as appropriate
- [ ] I have checked `Terraform Init` and `Terraform Fmt`
- [ ] I have ran `Terraform Apply` against any active module changes
