### PR TITLE
Comment out passcode not present smart group resource

### DIFF
--- a/modules/configuration-jamf-pro-smart-groups/main.tf
+++ b/modules/configuration-jamf-pro-smart-groups/main.tf
@@ -132,13 +132,13 @@ resource "jamfpro_smart_mobile_device_group" "group_last_checkin" {
 #   }
 # }
 
-resource "jamfpro_smart_mobile_device_group" "group_passcode_not_present" {
-  name = "*Passcode Not Present"
+# resource "jamfpro_smart_mobile_device_group" "group_passcode_not_present" {
+#   name = "*Passcode Not Present"
 
-  criteria {
-    name        = "Passcode Status"
-    priority    = 0
-    search_type = "is"
-    value       = "Not Present"
-  }
-}
+#   criteria {
+#     name        = "Passcode Status"
+#     priority    = 0
+#     search_type = "is"
+#     value       = "Not Present"
+#   }
+# }


### PR DESCRIPTION
The jamfpro_smart_mobile_device_group resource for devices without a passcode has been commented out, likely to disable its creation without deleting the configuration.

# Change

**_State your intended change to Experience Jamf_**

> Thank you for your contribution!
> Please include a summary of the change and which issue is fixed.
> Please also include relevant motivation and context.
> List any dependencies that are required for this change.

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update (Wiki)
- [ ] Refactor (refactoring code, removing code, changing code structure)
- [ ] Release to main from staging branch

## Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] For module changes - I have included an example in the /examples directory and a README.md in the module root
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated spec.yaml as appropriate
- [ ] I have checked `Terraform Init` and `Terraform Fmt`
- [ ] I have ran `Terraform Apply` against any active module changes
